### PR TITLE
Implemented ParsingClass.Parse function, minor changes to tests

### DIFF
--- a/Formatter_Tests/Formatter_Tests.cs
+++ b/Formatter_Tests/Formatter_Tests.cs
@@ -11,14 +11,14 @@ namespace Formatter_Tests
         [TestMethod]
         public void Seperate_line_into_sections_with_simple_example_data()
         {
-            string[] mockCsvData = { "1st_section,2nd_section,3rd_section", "4th_section,5th_section,6th_section" };
+            string[] mockCsvData = { "1st_section,2nd_section,3rd_section,4th_section", "5th_section,6th_section,7th_section,8th_section" };
 
             ParsingClass Parser = new CSV_Formatter.ParsingClass();
             string[,] mockParsedCsvData = Parser.Parse(mockCsvData);
 
-            string[,] expectedParsedCsvData = { { "1st_section", "2nd_section", "3rd_section" },
-                                                { "4th_section", "5th_section", "6th_section" } };
-            Assert.AreEqual(expectedParsedCsvData, mockParsedCsvData);
+            string[,] expectedParsedCsvData = { { "1st_section", "2nd_section", "3rd_section", "4th_section" },
+                                                { "5th_section", "6th_section", "7th_section", "8th_section" } };
+            CollectionAssert.AreEqual(expectedParsedCsvData, mockParsedCsvData);
         }
 
         [TestMethod]
@@ -30,7 +30,7 @@ namespace Formatter_Tests
             string[,] mockParsedCsvData = Parser.Parse(mockCsvData);
 
             string[,] expectedParsedCsvData = { { "1", "VSTest: MonolithTests.NancyTests.RootModuleTests.when_unauthorized_get_on_root_url_should_redirect_us_to_login_page", "OK", "510" } };
-            Assert.AreEqual(expectedParsedCsvData, mockParsedCsvData);
+            CollectionAssert.AreEqual(expectedParsedCsvData, mockParsedCsvData);
         }
 
         //Formatting tests
@@ -44,7 +44,7 @@ namespace Formatter_Tests
 
             FormattingClass Formatter = new FormattingClass();
             string[] mockFormattedData = Formatter.Format(parsedCsvData);
-            Assert.AreEqual(expectedFormattedData, mockFormattedData);
+            CollectionAssert.AreEqual(expectedFormattedData, mockFormattedData);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Formatter_Tests
 
             FormattingClass Formatter = new FormattingClass();
             string[] mockFormattedData = Formatter.Format(parsedCsvData);
-            Assert.AreEqual(expectedFormattedData, mockFormattedData);
+            CollectionAssert.AreEqual(expectedFormattedData, mockFormattedData);
         }
 
         [TestMethod]
@@ -69,7 +69,7 @@ namespace Formatter_Tests
 
             FormattingClass Formatter = new FormattingClass();
             string[] mockFormattedData = Formatter.Format(parsedCsvData);
-            Assert.AreEqual(expectedFormattedData, mockFormattedData);
+            CollectionAssert.AreEqual(expectedFormattedData, mockFormattedData);
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace Formatter_Tests
 
             FormattingClass Formatter = new FormattingClass();
             string[] mockFormattedData = Formatter.Format(parsedCsvData);
-            Assert.AreEqual(expectedFormattedData, mockFormattedData);
+            CollectionAssert.AreEqual(expectedFormattedData, mockFormattedData);
         }
     }
 }

--- a/Formatter_Tests/Formatter_Tests.cs
+++ b/Formatter_Tests/Formatter_Tests.cs
@@ -37,8 +37,8 @@ namespace Formatter_Tests
         [TestMethod]
         public void Format_the_parsed_data_into_a_human_readable_format()
         {
-            string[,] parsedCsvData = { { "1st_section", "2nd_section", "3rd_section" },
-                                        { "4th_section", "5th_section", "6th_section" } };
+            string[,] parsedCsvData = { { "1st_section", "2nd_section", "3rd_section", "4th_section" },
+                                        { "5th_section", "6th_section", "7th_section", "8th_section" } };
 
             string[] expectedFormattedData = { "1st section", "2nd section", "3rd section", "4th section", "5th section", "6th section" };
 

--- a/TeamCity_CSV_Formatter/Classes/ParsingClass.cs
+++ b/TeamCity_CSV_Formatter/Classes/ParsingClass.cs
@@ -19,9 +19,36 @@ namespace CSV_Formatter
                 bar += c;
             }
             */
+            int lengthOfParsedCsvDataArray = 4; //Should match number of columns in CSV file
 
-            string[,] temp = { { "" } };
-            return temp;
+            string[,] parsedCsvData = new string[csvData.Length, lengthOfParsedCsvDataArray]; //[Y,X]
+            int xCoordinateOfArray = 0;
+            for (int i = 0; i < csvData.Length; i++)
+            {
+                string stringBuffer = string.Empty;
+                string itemToParse = csvData[i];
+
+                foreach (char c in itemToParse) //Doesn't parse the 3rd_section part. Use a for loop with string.length as stop param. Can use string[j] as method to access chars in string.
+                {
+                    if (c == ',')
+                    {
+                        parsedCsvData[i, xCoordinateOfArray] = stringBuffer;
+                        stringBuffer = "";
+
+                        xCoordinateOfArray += 1;
+                        if (xCoordinateOfArray > (lengthOfParsedCsvDataArray - 1))
+                        {
+                            xCoordinateOfArray = 0;
+                        }
+                    }
+                    else
+                    {
+                        stringBuffer += c;
+                    }
+                }
+            }
+
+            return parsedCsvData;
         }
     }
 }

--- a/TeamCity_CSV_Formatter/Classes/ParsingClass.cs
+++ b/TeamCity_CSV_Formatter/Classes/ParsingClass.cs
@@ -12,39 +12,17 @@ namespace CSV_Formatter
     {
         public string[,] Parse(string[] csvData)
         {
-            /* ~~~ Example code for iterating through a string's chars ~~~
-            string foo = "hello world", bar = string.Empty;
-            foreach(char c in foo)
-            {
-                bar += c;
-            }
-            */
             int lengthOfParsedCsvDataArray = 4; //Should match number of columns in CSV file
 
             string[,] parsedCsvData = new string[csvData.Length, lengthOfParsedCsvDataArray]; //[Y,X]
-            int xCoordinateOfArray = 0;
-            for (int i = 0; i < csvData.Length; i++)
+
+            for (int i = 0; i < csvData.Length; i++) //Y coordinate of parsedCsvData
             {
-                string stringBuffer = string.Empty;
                 string itemToParse = csvData[i];
-
-                foreach (char c in itemToParse) //Doesn't parse the 3rd_section part. Use a for loop with string.length as stop param. Can use string[j] as method to access chars in string.
+                string[] splitString = itemToParse.Split(',');
+                for (int j = 0; j < splitString.Length; j++)
                 {
-                    if (c == ',')
-                    {
-                        parsedCsvData[i, xCoordinateOfArray] = stringBuffer;
-                        stringBuffer = "";
-
-                        xCoordinateOfArray += 1;
-                        if (xCoordinateOfArray > (lengthOfParsedCsvDataArray - 1))
-                        {
-                            xCoordinateOfArray = 0;
-                        }
-                    }
-                    else
-                    {
-                        stringBuffer += c;
-                    }
+                    parsedCsvData[i,j] = splitString[j];
                 }
             }
 


### PR DESCRIPTION
Assert.AreEqual doesn't work when comparing two arrays; had to use CollectionAssert instead.
Adjusted test data to include a 4th column of split data, so the format is more akin to the real CSV.

Probably not worth implementing a parameter on ParsingClass.Parse to change the number of columns in parsedCsvData at this time, as the format of the TeamCity CSV is unlikely to change. Can easily be changed in ParsingClass.Parse if need-be. May implement this if this program ends up being used for parsing other CSV files.
